### PR TITLE
Fix resurrection script aborting when encountering restricted paths in the file system

### DIFF
--- a/scripts/resurrect-repositories.rb
+++ b/scripts/resurrect-repositories.rb
@@ -2,6 +2,7 @@
 
 # file location: <anywhere; but advisable in the PATH>
 
+require 'tempfile'
 require "#{__dir__}/utilities/string.rb"
 
 def usage(exit_code = -1)
@@ -55,11 +56,11 @@ def find_git_remote_url(git_cmd, remote_name)
 end
 
 def find_git_repos_from_disk(path)
-  stderr = "/tmp/#{File.basename(__FILE__)}-stderr"
-  paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr}`
-  File.read(stderr).split("\n").each_with_index do |line, i|
-    i.zero? && puts("WARNING: Following errors occurred when traversing directories for git repositories:".yellow)
-    puts line.yellow
+  stderr = Tempfile.new()
+  paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr.path}`
+  unless File.zero?(stderr)
+    puts "WARNING: Following errors occurred when traversing directories for git repositories:".yellow
+    puts `cat #{stderr.path}`.yellow
   end
   paths.split("\n").sort
 end

--- a/scripts/resurrect-repositories.rb
+++ b/scripts/resurrect-repositories.rb
@@ -56,13 +56,18 @@ def find_git_remote_url(git_cmd, remote_name)
 end
 
 def find_git_repos_from_disk(path)
-  stderr = Tempfile.new()
-  paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr.path}`
-  unless File.zero?(stderr)
-    puts "WARNING: Following errors occurred when traversing directories for git repositories:".yellow
-    puts `cat #{stderr.path}`.yellow
+  stderr = Tempfile.new
+  begin
+    paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr.path}`
+    unless File.zero?(stderr.path)
+      puts "WARNING: Following errors occurred when traversing directories for git repositories:".yellow
+      puts `cat #{stderr.path}`.yellow
+    end
+    return paths.split("\n").sort
+  ensure
+    stderr.close
+    stderr.unlink
   end
-  paths.split("\n").sort
 end
 
 def read_git_repos_from_file(filename)

--- a/scripts/resurrect-repositories.rb
+++ b/scripts/resurrect-repositories.rb
@@ -55,7 +55,13 @@ def find_git_remote_url(git_cmd, remote_name)
 end
 
 def find_git_repos_from_disk(path)
-  Dir.glob("#{path}/**/.git").map { |d| d.sub('/.git', '') }.compact.sort.uniq
+  stderr = "/tmp/#{File.basename(__FILE__)}-stderr"
+  paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr}`
+  File.read(stderr).split("\n").each_with_index do |line, i|
+    i.zero? && puts("WARNING: Following errors occurred when traversing directories for git repositories:".yellow)
+    puts line.yellow
+  end
+  paths.split("\n").sort
 end
 
 def read_git_repos_from_file(filename)


### PR DESCRIPTION
- Use `find` command to traverse the file system for git repositories
- Errors from `find` command are collected in a temp file and shown as warning to the user. These errors will not stop the resurrection script.

Note:
- Git repositories under hidden paths are found as well. With `glob` implementation thats not the case