### PR TITLE
Skip git repos inside hidden directories in resurrection script

### DIFF
--- a/scripts/resurrect-repositories.rb
+++ b/scripts/resurrect-repositories.rb
@@ -58,7 +58,7 @@ end
 def find_git_repos_from_disk(path)
   stderr = Tempfile.new
   begin
-    paths = `find '#{path}' -name .git -type d -exec dirname {} \\; 2>#{stderr.path}`
+    paths = `find '#{path}' -name .git -type d -not -regex '.*/\\..*/\\.git' -exec dirname {} \\; 2>#{stderr.path}`
     unless File.zero?(stderr.path)
       puts "WARNING: Following errors occurred when traversing directories for git repositories:".yellow
       puts `cat #{stderr.path}`.yellow


### PR DESCRIPTION
The [`find` command](https://github.com/vraravam/dotfiles/blob/master/scripts/resurrect-repositories.rb#L61) used for traversing the filesystem for Git repos includes results from hidden directories eg. `~/.cache/some/repo/.git`. 

I have updated the `find` command to skip Git repos under hidden directories by using `-not -regex` flags. The regex I have used to tell if a path is hidden or not is `.*/\..*/\.git`. The regex basically checks if the path of the Git repo contains at least one directory that starts with `.` 

<img width="961" alt="image" src="https://github.com/user-attachments/assets/c4a7bfce-64e2-498d-a1c3-57b2ee5bc051">


