### PR TITLE
Restructuring the README: Move explanation of env vars into .zprofile to avoid duplication

### DIFF
--- a/GettingStarted-Basic.md
+++ b/GettingStarted-Basic.md
@@ -8,12 +8,6 @@ On your local machine:
    * Search for 'Full Disk Access' and add 'Terminal' (if not, the setup script will error out in between)
    * Search for 'File Vault' and turn it on (if not, then the setup script will exit in the beginning itself)
 
-In your forked repo, make the following changes, commit and push (Once the above steps are done, and committed into your fork, then everytime you need to run the setup, you can run the `curl` commands that point to your fork instead of mine so as to avoid manual effort.):
-
-1. **_Only in this README file and `files/.zprofile` files (and nowhere else):_** Find and replace the strings that reference my usernames to your equivalent ones (for eg, you can search for `vraravam` and `avijayr` and replace them with your values).
-2. The nested folder names that you choose for your setup (as referred to by `PROJECTS_BASE_DIR`, `PERSONAL_CONFIGS_DIR`, `PERSONAL_PROFILES_DIR`, `PERSONAL_BIN_DIR`, and `DOTFILES_DIR` in the `files/.zprofile` file) **should be reflected** in the folder structure of the nested folders in the `files` directory of the committed github repo itself. For eg, I have `PROJECTS_BASE_DIR="${HOME}/dev"`, and if your setup uses `workspace` instead of `dev`, then, in your forked repository, the folder name `files/dev` should be renamed to `files/workspace` and so on.
-3. Review all entries in the `${HOME}/Brewfile`, and ensure that there are no unwanted libraries/files. If you have any doubts (if comparing with my Brewfile), you will need to search the internet for the uses of those libraries/applications.
-
 The meta script to setup the macos machine from a vanilla OS can be run using the following command:
 
 ```zsh

--- a/GettingStarted-Basic.md
+++ b/GettingStarted-Basic.md
@@ -42,4 +42,4 @@ All these scripts are optimized for fast loading of the shell so that the user c
    * Search for 'iCloud' and login setup Desktop sync
 2. Open the `Finder` application and manually adjust the Finder sidebar preferences
 
-Back to [Readme](README.md#basic-setup)
+Back to [Readme](README.md#basic-setup) | Continue with the [advanced setup](GettingStarted-Advanced.md)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Background
 
-This repo was created from the gists that I was using to help others adopt my machine setup. It contains the common dotfiles as well as the scripts that I use to share the machine setup.
+This repo is used to backup and easily reimage a new macos system. It contains the common dotfiles as well as the scripts that I use as the backup/restore strategy.
 
 These scripts are idempotent and can run on a vanilla OS as well as once the whole setup has been completed.
 
@@ -45,9 +45,9 @@ Once the above is done, and if you have setup the [keybase](https://keybase.io)-
 
 As a summary, these files will typically have changes between your setup and mine:
 
-* `README.md` & `GettingStarted-Basic.md` (references to your usernames instead of mine, and typically any other changes that you introduce in the `files/.zprofile` - look below)
+* `GettingStarted-Basic.md` (references to your usernames instead of mine, and typically any other changes that you introduce in the `files/.zprofile` - look below)
 * `files/.gitconfig` (the `IncludeIf` line to match your global/base configuration filename)
-* `files/.zprofile` (`GH_USERNAME`, `KEYBASE_USERNAME`, and other changeable env vars from the above table)
+* `files/.zprofile` (`GH_USERNAME`, `KEYBASE_USERNAME`, and other changeable env vars to control which steps to perform vs which to bypass)
 * `files/Brewfile` (the list of applications and command-line utilities that you choose to install in your local machine)
 * `scripts/capture-defaults.sh` (what application preferences that you choose to backup - based on the entries in the `Brewfile`)
 * `scripts/fresh-install-of-osx.sh` (what applications you choose to set as login items on every reboot)
@@ -56,7 +56,7 @@ As a summary, these files will typically have changes between your setup and min
 
 The backup strategy is **not a one-off activity**. It will require you to take snapshots from time-to-time. Similarly, adherance to maintainence of the "catalogs" will need to be strictly upheld for the backup strategy to be effective.
 
-* Ensure that the software catalogs (`files/Brewfile`, `scripts/fresh-install-of-osx.sh`, `scripts/capture-defaults.sh`, `${HOME}/.tool-versions`) are always kept in sync with the actual applications that you install and use
+* Ensure that the software catalogs (`files/Brewfile`, `scripts/fresh-install-of-osx.sh`, `scripts/capture-defaults.sh`) are always kept in sync with the actual applications that you install and use
 * Ensure that the git repo catalogs that you are "tracking" in the `${PERSONAL_CONFIGS_DIR}/repositories-*.yml` files are kept up-to-date so that resurrection in your new machine will be seamless
 * Ensure to run the `scripts/capture-defaults.sh` (with the export switch) to export and capture/backup your preferences for all installed applications from your current machine
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 - [Background](#background)
+- [How to adopt/customize the scripts to your own settings](#how-to-adoptcustomize-the-scripts-to-your-own-settings)
 - [Pre-requisites](#pre-requisites)
 - [Basic setup](#basic-setup)
 - [Advanced setup (in addition to the basic setup if you want to capture other files in an encrypted private git repo)](#advanced-setup-in-addition-to-the-basic-setup-if-you-want-to-capture-other-files-in-an-encrypted-private-git-repo)
@@ -14,22 +15,17 @@ These scripts are idempotent and can run on a vanilla OS as well as once the who
 
 Each script will warn the users if its skipping a step, and if you want to rerun the script but force that step, you just need to delete the control `if` condition (you should have a basic understanding of shell programming to figure out what to delete/how to force without bypass).
 
-Most of the folder structures are governed by the following environment variables [defined here](files/.zprofile). If you do not wish to configure a specific folder, just delete it from the `.zprofile` and all other setup steps should adhere to that decision.
+All of the folder structures and the setup/backup operations are governed by the environment variables [defined here](files/.zprofile). Please read the explanation of each variable in the same and edit appropriately.
 
-| Env var| Meaning | Default Value |
-| -------|---------|---------------|
-| `GH_USERNAME` | The github username | "vraravam" |
-| `UPSTREAM_GH_USERNAME` | Vijay's github username for setting upstream remote **Do NOT change** | "vraravam" |
-| `PROJECTS_BASE_DIR` | All codebases are cloned into a subfolder of this folder | "${HOME}/dev" |
-| `PERSONAL_CONFIGS_DIR` | Many configuration files (eg `.envrc`, `.tool-versions`), that might contain sensitive info and so cannot be committed into those repos are stored here and symlinked to their target destination | "${HOME}/personal/dev/configs" |
-| `PERSONAL_BIN_DIR` | Executable scripts that are not shared as part of this repo are present here | "${HOME}/personal/dev/bin" |
-| `PERSONAL_PROFILES_DIR` | All browser profiles are captured in this folder | "${HOME}/personal/$(whoami)/profiles" |
-| `DOTFILES_DIR` | This repo is cloned here | "${HOME}/.bin-oss" |
-| `KEYBASE_USERNAME` | Keybase username | "avijayr" |
-| `KEYBASE_HOME_REPO_NAME` | Keybase home repo name | "home" |
-| `KEYBASE_PROFILES_REPO_NAME` | Keybase profiles repo name | "profiles" |
+# How to adopt/customize the scripts to your own settings
 
-**If you want to be able to re-image a new machine with your settings (and overridden choices), and do not want to repeat the steps  manually, you would want to fork my repo and make appropriate changes.**
+If you want to be able to re-image a new machine with your own settings (and overridden choices), and you do not want to repeat these steps manually, you would want to fork my repo and make appropriate changes into your fork.
+
+In your forked repo, make the following changes, commit and push. Once the above steps are done, and committed into your fork, then everytime you need to run the setup, you can run the `curl` commands that point to *your* fork:
+
+1. **_Only in this file, `GettingStarted-Basic.md` and `files/.zprofile` files (and nowhere else):_** Find and replace the strings that reference my usernames to your equivalent ones (for eg, you can search for `vraravam` and `avijayr` and replace them with your values).
+2. The nested folder names that you choose for your setup (as referred to by `PROJECTS_BASE_DIR`, `PERSONAL_CONFIGS_DIR`, `PERSONAL_PROFILES_DIR`, `PERSONAL_BIN_DIR`, and `DOTFILES_DIR` in the `files/.zprofile` file) **should be reflected** in the folder structure of the nested folders in the `files` directory of the committed github repo itself. For eg, I have `PROJECTS_BASE_DIR="${HOME}/dev"`, and if your setup uses `workspace` instead of `dev`, then, in your forked repository, the folder name `files/dev` should be renamed to `files/workspace` and so on.
+3. Review all entries in the `${HOME}/Brewfile`, and ensure that there are no unwanted libraries/applications. If you have any doubts (if comparing with my Brewfile), you will need to search the internet for the uses of those libraries/applications.
 
 # Pre-requisites
 

--- a/files/.zprofile
+++ b/files/.zprofile
@@ -31,14 +31,36 @@ export LESSCHARSET='utf-8'
 export XDG_CACHE_HOME="${HOME}/.cache"
 export XDG_CONFIG_HOME="${HOME}/.config"
 
-# Note: Change these as per your settings. Deleting them will essentially unset the var(s) and thus any aliases/paths/etc will not be processed for those deleted variable(s)
+# Note: Change these as per your settings. Deleting them will essentially unset the var(s) and thus any aliases/backup-operations/etc will not be processed for those deleted variable(s)
+
+# ------------ Env vars for basic/common setup ------------
+# The github username where the setup scripts are downloaded from
 export GH_USERNAME="vraravam"
+
+# Vijay's github username for setting upstream remote
 export UPSTREAM_GH_USERNAME="vraravam" # Note: Do NOT change this
-export PROJECTS_BASE_DIR="${HOME}/dev"
-export PERSONAL_CONFIGS_DIR="${HOME}/personal/dev/configs"
-export PERSONAL_BIN_DIR="${HOME}/personal/dev/bin"
-export PERSONAL_PROFILES_DIR="${HOME}/personal/$(whoami)/profiles"
+
+# This repo is cloned into this location
 export DOTFILES_DIR="${HOME}/.bin-oss"
+
+# All development codebases are cloned into a subfolder of this folder
+export PROJECTS_BASE_DIR="${HOME}/dev"
+
+# Executable scripts that are not shared as part of this public repo are present here
+export PERSONAL_BIN_DIR="${HOME}/personal/dev/bin"
+
+# Many configuration files (eg `.envrc`, `.tool-versions`), that might contain sensitive info and so cannot be committed into those repos are stored here and symlinked to their target destination
+export PERSONAL_CONFIGS_DIR="${HOME}/personal/dev/configs"
+
+# ------------ Env vars for advanced setup ------------
+# All browser profiles are captured in this folder (might contain sensitive info like browsing history and so is considered private)
+export PERSONAL_PROFILES_DIR="${HOME}/personal/$(whoami)/profiles"
+
+# Keybase username
 export KEYBASE_USERNAME="avijayr"
+
+# Keybase home repo name
 export KEYBASE_HOME_REPO_NAME="home"
+
+# Keybase profiles repo name
 export KEYBASE_PROFILES_REPO_NAME="profiles"


### PR DESCRIPTION
As per @arunvelsriram 's suggestions, moving the explanation about the table of env vars into the .zprofile so that we can avoid duplication.