### PR TITLE
Stop processing the 'Brewfile' such that the minimal installation can happen in a shorter duration of time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ As documented in the README's [adopting](README.md#how-to-adoptcustomize-the-scr
 
 For those who follow this repo, here's the changelog for ease of adoption:
 
+### 1.0-28
+
+* *[Brewfile]* Stop processing the `Brewfile` such that the minimal installation can happen in a shorter duration of time. This is controlled by the env var `HOMEBREW_BASE_INSTALL` which is set in the `fresh-install-of-osx.sh` script when installing from scratch.
+
 ### 1.0-27
 
 * *[.aliases]* Added 2 new utility functions: `count` and `count_all_repos`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The "advanced" setup is the set of final steps to capture your application prefe
 
 # Finally...
 
+With this latest version, the `files/--HOME--/Brewfile` will be run only with the bare minimum of formulae. Once the process completes, and you restart the Terminal app, you would want to run `bupc` so that all the other applications can be installed.
+
 Once the above is done, and if you have setup the [keybase](https://keybase.io)-based home repo, profile repo, etc - you can then re-import your exported preferences from the [pre-requisites section](#pre-requisite-if-you-want-to-capture-data-from-your-current-mac).
 
 Of course, you will have to manually take snapshots of your machine for backup from time-to-time as an *ongoing activity*. This can be done using the `scripts/capture-defaults.sh` script and pushing into the remote repo of your home folder. (More details can be found in the next section.)

--- a/files/--HOME--/Brewfile
+++ b/files/--HOME--/Brewfile
@@ -21,6 +21,9 @@ cask_args appdir: '/Applications', fontdir: '/Library/Fonts', no_quarantine: tru
 # java_present = system('/usr/libexec/java_home --failfast')
 is_arm = Hardware::CPU.arm?
 
+is_base_install = ENV.has_key?('HOMEBREW_BASE_INSTALL')
+puts "Only performing base installation!" if is_base_install
+
 tap 'homebrew/services'
 tap 'romkatv/powerlevel10k'
 
@@ -38,6 +41,11 @@ brew 'diff-so-fancy'
 brew 'direnv'
 brew 'mise'
 brew 'powerlevel10k'
+
+# casks pulled in for base configs
+cask 'font-meslo-lg-nerd-font'
+
+return if is_base_install
 
 # formulae pulled in for advanced configs (these are optional, but still recommended)
 brew 'bat'
@@ -59,7 +67,6 @@ cask 'arc'
 cask 'brave-browser'
 cask 'clocker'
 cask 'firefox@nightly' #, greedy: true
-cask 'font-meslo-lg-nerd-font'
 cask 'iterm2'
 cask 'itsycal'
 cask 'jordanbaird-ice'

--- a/scripts/fresh-install-of-osx.sh
+++ b/scripts/fresh-install-of-osx.sh
@@ -235,7 +235,7 @@ else
   warn "skipping installation of homebrew since it's already installed"
 fi
 # TODO: Need to investigate why this step exits on a vanilla OS's first run of this script
-brew bundle check || brew bundle --all --cleanup || true
+HOMEBREW_BASE_INSTALL=true brew bundle check || HOMEBREW_BASE_INSTALL=true brew bundle --all --cleanup || true
 success 'Successfully installed cmd-line and gui apps using homebrew'
 
 # Note: Load all zsh config files for the 2nd time for PATH and other env vars to take effect (due to defensive programming)


### PR DESCRIPTION
This is controlled by the env var `HOMEBREW_BASE_INSTALL` which is set in the `fresh-install-of-osx.sh` script when installing from scratch.