### PR TITLE
Use 'zsh-defer' to defer loading of some plugins that are only needed after user-interaction starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ As documented in the README's [adopting](README.md#how-to-adoptcustomize-the-scr
 
 For those who follow this repo, here's the changelog for ease of adoption:
 
+### 1.0-14
+
+* Use 'zsh-defer' to try to bring down shell startup time.
+
 ### 1.0-13
 
 * *[.shellrc]* Introduced new utility functions `section_header` and `debug` and standardized on usages.
@@ -49,7 +53,7 @@ For those who follow this repo, here's the changelog for ease of adoption:
 ### 1.0-4
 
 * *[install-dotfiles.rb]* Refactored environment variable resolution logic to use `gsub!` for improved performance.
-  
+
 ### 1.0-3
 
 * Moved all files & nested folders inside the `files` directory into `files/--HOME--` to make that location explicit (earlier it was implied)

--- a/files/--HOME--/.zshrc
+++ b/files/--HOME--/.zshrc
@@ -114,13 +114,19 @@ export ZSH_AUTOSUGGEST_STRATEGY=(history completion)
 # Custom plugins may be added to ${ZSH_CUSTOM}/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(brew direnv eza fast-syntax-highlighting git git-extras iterm2 mise sudo zbell zsh-autosuggestions)
+plugins=(brew direnv eza git mise sudo zbell zsh-defer)
+deferred_plugins=(fast-syntax-highlighting git-extras iterm2 zsh-autosuggestions)
 
 # according to https://github.com/zsh-users/zsh-completions/issues/603#issue-373185486, this can't be added as a plugin to omz for the fpath to work correctly
 export ZSH_CUSTOM="${ZSH_CUSTOM:-"${ZSH:-"${HOME}/.oh-my-zsh"}/custom"}"
 append_to_fpath_if_dir_exists "${ZSH_CUSTOM}/plugins/zsh-completions/src"
 
 load_file_if_exists "${ZSH}/oh-my-zsh.sh"
+
+# Defer the loading of these plugins since they are only needed in interactive mode
+for deferred_plugin in "${deferred_plugins[@]}"; do
+  zsh-defer load_file_if_exists "${ZSH_CUSTOM}/plugins/${deferred_plugin}/${deferred_plugin}.plugin.zsh"
+done
 
 # User configuration
 # export MANPATH="/usr/local/man${MANPATH+:$MANPATH}"
@@ -150,10 +156,10 @@ export ARCHFLAGS="-arch $(uname -m)"
 # alias zshconfig="${EDITOR} ${ZDOTDIR}/.zshrc"
 # alias ohmyzsh="${EDITOR} ${ZSH}"
 
-load_file_if_exists "${HOME}/.zshrc.custom"
+zsh-defer load_file_if_exists "${HOME}/.zshrc.custom"
 
 # remove duplicates from some env vars
-typeset -gU cdpath CPPFLAGS cppflags FPATH fpath infopath LDFLAGS ldflags MANPATH manpath PATH path PKG_CONFIG_PATH
+zsh-defer typeset -gU cdpath CPPFLAGS cppflags FPATH fpath infopath LDFLAGS ldflags MANPATH manpath PATH path PKG_CONFIG_PATH
 
 # for profiling zsh, see: https://unix.stackexchange.com/a/329719/27109
 # execute 'ZSH_PROFILE_RC=true zsh' and run 'zprof' to get the details

--- a/files/--HOME--/.zshrc.custom
+++ b/files/--HOME--/.zshrc.custom
@@ -23,7 +23,7 @@ append_to_path_if_dir_exists "${PROJECTS_BASE_DIR}/oss/git_scripts"
 # Note: Not sure if its a bug, but the first iterm tab alone has all the paths, but these are missing in subsequent tabs and new windows
 append_to_path_if_dir_exists "/usr/local/bin"
 
-load_file_if_exists "${HOME}/.aliases"
+zsh-defer load_file_if_exists "${HOME}/.aliases"
 
 # erlang history in iex
 # export ERL_AFLAGS="-kernel shell_history enabled -kernel shell_history_file_bytes 1024000"
@@ -188,7 +188,7 @@ export CUCUMBER_COLORS="pending_param=magenta:failed_param=magenta:passed_param=
 export RSPEC="true"
 
 # fzy
-# load_file_if_exists "${HOME}/.fzy-key-bindings.zsh"
+# zsh-defer load_file_if_exists "${HOME}/.fzy-key-bindings.zsh"
 
 # remove empty components to avoid '::' ending up + resulting in './' being in $PATH, etc
 path=( "${path[@]:#}" )

--- a/scripts/fresh-install-of-osx.sh
+++ b/scripts/fresh-install-of-osx.sh
@@ -98,6 +98,7 @@ clone_if_not_present() {
 clone_if_not_present https://github.com/zdharma-continuum/fast-syntax-highlighting
 clone_if_not_present https://github.com/zsh-users/zsh-autosuggestions
 clone_if_not_present https://github.com/zsh-users/zsh-completions
+clone_if_not_present https://github.com/romkatv/zsh-defer
 
 ####################
 # Install dotfiles #

--- a/scripts/software-updates-cron.sh
+++ b/scripts/software-updates-cron.sh
@@ -43,5 +43,10 @@ else
   debug "skipping updating omz"
 fi
 
-echo "---- Updating brews"
-bupc
+if command_exists brew; then
+  section_header "Updating brews"
+  # for some reason, with 'zsh-defer' the aliases are not loaded, and so can't use 'bupc' directly
+  brew bundle check || brew bundle --all --cleanup; brew bundle cleanup -f; brew cleanup --prune=all; brew autoremove
+else
+  debug "skipping updating brews & casks"
+fi


### PR DESCRIPTION
From [here](https://github.com/romkatv/zsh-defer)

Without `zsh-defer`, here are the times: 
<img width="542" alt="Screenshot 2024-12-07 at 22 14 36" src="https://github.com/user-attachments/assets/d6f91f74-26ce-4fcd-b342-9540e246e79b">

with `zsh-defer`, here are the times: 
<img width="718" alt="Screenshot 2024-12-07 at 22 14 04" src="https://github.com/user-attachments/assets/119fd6ae-7798-4a7a-a768-43264b1c7d3d">

So, at least according to these 2 screenshots, `zsh-defer` definitely has a positive impact on reducing the shell startup times! Would love to see others' experience before merging this PR.