### PR TITLE
Add printing the start and end time while running fresh-install-of-osx.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ As documented in the README's [adopting](README.md#how-to-adoptcustomize-the-scr
 
 For those who follow this repo, here's the changelog for ease of adoption:
 
+### 1.0-32
+
+* *[fresh-install-of-osx]* Added date calculation in `fresh-install-of-osx.sh` to track total execution time.
+
 ### 1.0-31
 
 * *[approve-fingerprint-sudo.sh]* Handled case to execute `approve-fingerprint-sudo.sh` based on touchId hardware.

--- a/scripts/fresh-install-of-osx.sh
+++ b/scripts/fresh-install-of-osx.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
+script_start_time=$(date +%s)
+echo "==> Script started at: $(date)"
 
 # vim:filetype=zsh syntax=zsh tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent fileencoding=utf-8
 
@@ -490,3 +492,7 @@ fi
 
 echo "\n"
 success '** Finished auto installation process: MANUALLY QUIT AND RESTART iTerm2 and Terminal apps **'
+
+script_end_time=$(date +%s)
+echo "==> Script completed at: $(date)"
+echo "==> Total execution time: $((script_end_time - script_start_time)) seconds"

--- a/scripts/fresh-install-of-osx.sh
+++ b/scripts/fresh-install-of-osx.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env zsh
-script_start_time=$(date +%s)
-echo "==> Script started at: $(date)"
 
 # vim:filetype=zsh syntax=zsh tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent fileencoding=utf-8
 
@@ -13,6 +11,9 @@ echo "==> Script started at: $(date)"
 # 1. Auto-adjust Brightness
 # 2. Brightness on battery
 # 3. Keyboard brightness
+
+script_start_time=$(date +%s)
+echo "==> Script started at: $(date)"
 
 #############################################################
 # Utility scripts and env vars used only within this script #


### PR DESCRIPTION
This should/would theoretically motivate contributors to improve performance of this script and later, get a "full installation"