### PR TITLE
Add script for importing Raycast settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ As documented in the README's [adopting](README.md#how-to-adoptcustomize-the-scr
 
 For those who follow this repo, here's the changelog for ease of adoption:
 
+### 1.0-45
+
+* *[capture-raycast-configs.sh]* Added script to export/import raycast configs. More details can be found [here](Extras.md#capture-raycast-configssh).
+
 ### 1.0-44
 
 * *[recreate-repo.sh]* Fix an issue where a trailing slash would not properly process the repo in `${PERSONAL_PROFILES_DIR}` (ie would not force-squash)

--- a/Extras.md
+++ b/Extras.md
@@ -28,7 +28,9 @@ This script is useful to capture the preferences of the known applications (both
 This script is useful to capture the raycast preferences/configurations. It can be used to both export the preferences/settings (from the old system) or import them (into the new system)
 
   ```bash
+  export RAYCAST_SETTINGS_PASSWORD='my-passoword'
   capture-raycast-configs.sh e "${PERSONAL_PROFILES_DIR}/extension-backups"
+  capture-raycast-configs.sh i "${PERSONAL_PROFILES_DIR}/extension-backups"
   ```
 
 *Please note:*

--- a/Extras.md
+++ b/Extras.md
@@ -23,6 +23,23 @@ Note:
 
 This script is useful to capture the preferences of the known applications (both system-installed and custom-installed applications) using the `defaults read` command. It can be used to both export the preferences/settings (from the old system) or import them (into the new system)
 
+## capture-raycast-configs.sh
+
+This script is useful to capture the raycast preferences/configurations. It can be used to both export the preferences/settings (from the old system) or import them (into the new system)
+
+  ```bash
+  capture-raycast-configs.sh e "${PERSONAL_PROFILES_DIR}/extension-backups"
+  ```
+
+*Please note:*
+
+Since this script uses applescript internally, it needs to be granted the following permissions:
+
+* `Privacy & Security > Accessibility` - need to enable/approve for iTerm and Terminal apps.
+* `Privacy & Security > Automation` - need to enable/approve for "System Events" for iTerm and Terminal apps.
+* Also, since this mimics keystrokes from the user, while this script is running, you should not move the mouse or type anything else using the keyboard or mouse.
+* The above manual steps have to be performed after installing Raycast and running it at least once (so one has to click through the setup wizard). Due to this reason, this script has NOT been incorporated into the `fresh-install-of-osx.sh` script.
+
 ## cleanup-browser-profiles.sh
 
 This script is used to cleanup browser profiles folders (delete cache, session and other files that will anyways be recreated when you restart that browser). It can be safely invoked even if that browser is running (in which case it will skip processing after printing a warning to quit that application)

--- a/scripts/capture-raycast-configs.sh
+++ b/scripts/capture-raycast-configs.sh
@@ -28,7 +28,7 @@ local target_file="${target_dir}/Raycast.rayconfig"
 ensure_dir_exists "${target_dir}"
 
 if [[ "${1}" == 'e' ]]; then
-  rm -rfv "${target_dir}"/Raycast*.rayconfig
+  [ -f "${target_dir}"/Raycast.rayconfig ] && rm -rfv "${target_dir}"/Raycast.rayconfig
 
   open raycast://extensions/raycast/raycast/export-settings-data
 

--- a/scripts/capture-raycast-configs.sh
+++ b/scripts/capture-raycast-configs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env zsh
+
+# vim:filetype=zsh syntax=zsh tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent fileencoding=utf-8
+
+# file location: <anywhere; but advisable in the PATH>
+
+# This script will export/import the raycast configs to/from the location specified in the target directory.
+# Reference for keystrokes/keycodes: https://eastmanreference.com/complete-list-of-applescript-key-codes
+
+type warn &> /dev/null 2>&1 || source "${HOME}/.shellrc"
+
+set -euo pipefail
+
+usage() {
+  echo "$(red "Usage"): $(yellow "${1} <e/i> <target-dir-location>")"
+  echo "  $(yellow 'e')                   --> Export from system"
+  echo "  $(yellow 'i')                   --> Import into system"
+  echo "  $(yellow 'target-dir-location') --> Directory name where the config has to be exported to/imported from"
+  exit 1
+}
+
+[ $# -ne 2 ] && usage "${0}"
+
+[[ "${1}" != 'e' && "${1}" != 'i' ]] && echo "$(red 'Unknown value entered') for first argument: '${1}'" && usage "${0}"
+
+local target_dir="${2}"
+local target_file="${target_dir}/Raycast.rayconfig"
+ensure_dir_exists "${target_dir}"
+
+if [[ "${1}" == 'e' ]]; then
+  rm -rfv "${target_dir}"/Raycast*.rayconfig
+
+  open raycast://extensions/raycast/raycast/export-settings-data
+
+  osascript <<EOF
+    tell application "System Events"
+      key code 36
+      delay 0.3
+
+      key code 5 using {command down, shift down}
+      delay 0.3
+
+      keystroke "${target_dir}"
+      delay 0.3
+
+      key code 36
+      delay 0.3
+
+      key code 36
+      delay 0.5
+
+      key code 53
+    end tell
+EOF
+
+  mv "${target_dir}"/Raycast*.rayconfig "${target_file}"
+  success "Exported raycast configs to: $(yellow "${target_file}")"
+elif [[ "${1}" == 'i' ]]; then
+  ! is_file "${target_file}" && error "Couldn't find file: '$(yellow "${target_file}")' for import operation; Aborting!!!"
+
+  open raycast://extensions/raycast/raycast/import-settings-data
+
+  # TODO: Need to get import working
+  osascript <<EOF
+    tell application "System Events"
+      key code 36
+      delay 0.3
+
+      keystroke "${target_file}"
+      delay 0.3
+
+      key code 36
+      delay 0.3
+    end tell
+EOF
+
+  success "Imported raycast configs from: $(yellow "${target_file}")"
+fi

--- a/scripts/capture-raycast-configs.sh
+++ b/scripts/capture-raycast-configs.sh
@@ -58,20 +58,41 @@ EOF
 elif [[ "${1}" == 'i' ]]; then
   ! is_file "${target_file}" && error "Couldn't find file: '$(yellow "${target_file}")' for import operation; Aborting!!!"
 
+  # TODO: Get this from password manager
+  password=$RAYCAST_SETTINGS_PASSWORD
+
   open raycast://extensions/raycast/raycast/import-settings-data
 
-  # TODO: Need to get import working
   osascript <<EOF
     tell application "System Events"
-      key code 36
-      delay 0.3
+    key code 36
+    delay 0.3
 
-      keystroke "${target_file}"
-      delay 0.3
+    key code 5 using {command down, shift down}
+    delay 0.3
 
-      key code 36
-      delay 0.3
-    end tell
+    keystroke "${target_dir}/Raycast.rayconfig"
+    delay 0.3
+
+    key code 36
+    delay 0.5
+
+    key code 36
+    delay 0.3
+
+    keystroke "$password"
+    key code 36
+    delay 0.3
+
+    key code 36
+    delay 0.3
+
+    key code 36
+    delay 1
+
+    key code 53
+    key code 53
+  end tell
 EOF
 
   success "Imported raycast configs from: $(yellow "${target_file}")"


### PR DESCRIPTION
Dependent PR: #14 

- Fix issue when removing non-existent Raycast settings file
- Add script to import Raycast settings
- The password of the Raycast settings file is passed via an env variable. This could be enhanced by fetching from password manager.

