### PR TITLE
Increase  delay for users to observe the Raycast settings import status

### DIFF
--- a/scripts/capture-raycast-configs.sh
+++ b/scripts/capture-raycast-configs.sh
@@ -85,7 +85,7 @@ elif [[ "${1}" == 'i' ]]; then
       delay 0.3
 
       key code 36
-      delay 1
+      delay 2
 
       key code 53
       key code 53


### PR DESCRIPTION
Raising as separate PR as this one #19 is closed.

For users to observe the status of the import (whether its successful or failed), I have introduced a delay to retain the status on screen.