### PR TITLE
Automate initial password setup for Raycast export

### DIFF
--- a/scripts/capture-raycast-configs.sh
+++ b/scripts/capture-raycast-configs.sh
@@ -25,6 +25,8 @@ local target_dir="${2}"
 local target_file="${target_dir}/Raycast.rayconfig"
 ensure_dir_exists "${target_dir}"
 
+! is_non_zero_string "${RAYCAST_SETTINGS_PASSWORD}" && error "Cannot proceed without the 'RAYCAST_SETTINGS_PASSWORD' env var set; Aborting!!!"
+
 if [[ "${1}" == 'e' ]]; then
   is_file "${target_dir}/Raycast.rayconfig" && rm -rf "${target_dir}/Raycast.rayconfig"
 
@@ -34,6 +36,20 @@ if [[ "${1}" == 'e' ]]; then
     tell application "System Events"
       key code 36
       delay 0.3
+
+      if (static text "Enter password" of window 1 of application process "Raycast") exists then
+        keystroke "${RAYCAST_SETTINGS_PASSWORD}"
+        delay 0.3
+
+        key code 36
+        delay 0.3
+
+        keystroke "${RAYCAST_SETTINGS_PASSWORD}"
+        delay 0.3
+
+        key code 36
+        delay 0.3
+      end if
 
       key code 5 using {command down, shift down}
       delay 0.3
@@ -55,8 +71,6 @@ EOF
   success "Successfully exported raycast configs to: $(yellow "${target_file}")"
 elif [[ "${1}" == 'i' ]]; then
   ! is_file "${target_file}" && error "Couldn't find file: '$(yellow "${target_file}")' for import operation; Aborting!!!"
-
-  ! is_non_zero_string "${RAYCAST_SETTINGS_PASSWORD}" && error "Cannot proceed without the 'RAYCAST_SETTINGS_PASSWORD' env var set; Aborting!!!"
 
   open raycast://extensions/raycast/raycast/import-settings-data
 


### PR DESCRIPTION
When exporting the Raycast settings for the first time a password needs to be configured. This PR automates the password setup by checking if Raycast Export Settings dialog is prompting for a password.

<img width="767" alt="image" src="https://github.com/user-attachments/assets/16085183-c3b1-4ebb-91ef-a459bd6deeda" />
<img width="786" alt="image" src="https://github.com/user-attachments/assets/044c3be9-f97f-4ff6-80a9-70fc450f3a1e" />


Ref: https://github.com/arunvelsriram/dotfiles/blob/main/raycast-export#L15-L27